### PR TITLE
Disable bundler installation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - jekyll
     - dev
-    - bundlertest
 
 skip_tags: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,7 @@ branches:
   only:
     - jekyll
     - dev
+    - bundlertest
 
 skip_tags: true
 

--- a/tools/appveyor.psm1
+++ b/tools/appveyor.psm1
@@ -14,7 +14,8 @@ Function Invoke-Install () {
     ruby --version
 
     Write-Verbose 'Installing bundler and required packages...'
-    gem install bundler
+    # Disable bundles itself, because it should already exist.
+    # gem install bundler
     bundle install
     #gem install jekyll
 }


### PR DESCRIPTION
Bundler is alread installed at the AppVeyor build workers:
- https://github.com/appveyor/ci/issues/1926

So I can disable this step.
