### PR TITLE
Modularize piwik config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -183,7 +183,9 @@ exclude:
   - tools/
 
 # --- Piwik Integration --- #
-piwik_id: "2"
+piwik:
+  site_id: "2"
+  uri: "piwik.beaver-net.ovh"
 
 gist:
   noscript: false

--- a/_includes/piwik.html
+++ b/_includes/piwik.html
@@ -1,4 +1,4 @@
-{% if site.piwik_id %}
+{% if site.piwik %}
   <!-- Piwik -->
   <script type="text/javascript">
     var _paq = _paq || [];
@@ -6,9 +6,9 @@
     _paq.push(['trackPageView']);
     _paq.push(['enableLinkTracking']);
     (function() {
-      var u="//piwik.beaver-net.ovh/";
+      var u="//{{- site.piwik.uri -}}/";
       _paq.push(['setTrackerUrl', u+'piwik.php']);
-      _paq.push(['setSiteId', '{{ site.piwik_id }}']);
+      _paq.push(['setSiteId', '{{- site.piwik.site_id -}}']);
       var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
       g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
     })();


### PR DESCRIPTION
- simplify piwik uri customization for repo forks. ([#1](https://github.com/n00b2h4ck3r/n00b2h4ck3r.github.io/pull/1))

- piwik config changed into this structure
```yaml
piwik:
  site_id: "<integer>"
  uri: "<basic uri without protocol and tailing slashes>"
````